### PR TITLE
Make baseColWidth use Excel's default

### DIFF
--- a/R/worksheet_class.R
+++ b/R/worksheet_class.R
@@ -56,7 +56,7 @@ WorkSheet$methods(initialize = function(showGridLines = TRUE,
   sheetPr <<- tabColour
   dimension <<- '<dimension ref="A1"/>'
   sheetViews <<- sprintf('<sheetViews><sheetView workbookViewId="0" zoomScale="%s" showGridLines="%s" tabSelected="%s"/></sheetViews>', as.integer(zoom), as.integer(showGridLines), as.integer(tabSelected))
-  sheetFormatPr <<- '<sheetFormatPr defaultRowHeight="15.0"/>'
+  sheetFormatPr <<- '<sheetFormatPr defaultRowHeight="15.0" baseColWidth="10"/>'
   cols <<- character(0)
 
   autoFilter <<- character(0)


### PR DESCRIPTION
Setting `baseColWidth` to `10` synchronizes the column width to Microsoft's XLSX standard since Excel 2007.